### PR TITLE
Use `Regex::foreach_names` instead of `Regex::capture_names`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,13 +99,15 @@ impl Pattern {
     pub fn new(regex: &str, alias: &HashMap<String, String>) -> Result<Self, Error> {
         match Regex::new(regex) {
             Ok(r) => Ok({
-                let names = HashMap::from_iter(r.capture_names().map(|(cap_name, cap_idx)| {
+                let mut names = HashMap::new();
+                r.foreach_name(|cap_name, cap_idx| {
                     let name = match alias.iter().find(|&(_k, v)| *v == cap_name) {
                         Some(item) => item.0.clone(),
                         None => String::from(cap_name),
                     };
-                    (name, cap_idx[0])
-                }));
+                    names.insert(name, cap_idx[0]);
+                    true
+                });
                 Pattern {
                     regex: r,
                     names: names,


### PR DESCRIPTION
The method `onig::Regex::capture_names` results in segmentation fault on 32-bit architectures. In addition, [it is removed from `onig` 5.0.0](https://github.com/rust-onig/rust-onig/commit/300a4f6969f1879a5b621289bff27baa9382dfa1).

This PR replaces `onig::Regex::capture_names` usage by `onig::Regex::foreach_name` which works without problems on 32-architectures.