### PR TITLE
The EMAILLOCALPART pattern was copied from an updated version, RFC3696 compliant

### DIFF
--- a/patterns/grok.pattern
+++ b/patterns/grok.pattern
@@ -1,6 +1,6 @@
 USERNAME [a-zA-Z0-9._-]+
 USER %{USERNAME}
-EMAILLOCALPART [a-zA-Z][a-zA-Z0-9_.+-=:]+
+EMAILLOCALPART [a-zA-Z0-9!#$%&'*+\-/=?^_`{|}~]{1,64}(?:\.[a-zA-Z0-9!#$%&'*+\-/=?^_`{|}~]{1,62}){0,63}
 EMAILADDRESS %{EMAILLOCALPART}@%{HOSTNAME}
 INT (?:[+-]?(?:[0-9]+))
 BASE10NUM (?<![0-9.+-])(?>[+-]?(?:(?:[0-9]+(?:\.[0-9]+)?)|(?:\.[0-9]+)))


### PR DESCRIPTION
Only the EMAILLOCALPART pattern has been updated.

Note: There are several other changes/updates in the upstream pattern, but some of them, mostly the `SYSLOG*` patterns, changed the output format which may cause different behaviour in projects using these patterns, so I didn't include those in the MR.